### PR TITLE
Add organisation_events support for param timeslot_start

### DIFF
--- a/lib/mobilize_america_client/client/events.rb
+++ b/lib/mobilize_america_client/client/events.rb
@@ -1,8 +1,8 @@
 module MobilizeAmericaClient
   class Client
     module Events
-      def organization_events(organization_id:, timeslot_start: nil, updated_since: nil, max_distance_miles: nil, page: nil, per_page: nil,
-                              zipcode: nil)
+      def organization_events(organization_id:, timeslot_start: nil, timeslot_end: nil, updated_since: nil,
+                              max_distance_miles: nil, page: nil, per_page: nil, zipcode: nil)
         params = {}
 
         unless page.nil?
@@ -15,6 +15,10 @@ module MobilizeAmericaClient
 
         unless timeslot_start.nil?
           params[:timeslot_start] = timeslot_start
+        end
+
+        unless timeslot_end.nil?
+          params[:timeslot_end] = timeslot_end
         end
 
         unless updated_since.nil?

--- a/lib/mobilize_america_client/client/events.rb
+++ b/lib/mobilize_america_client/client/events.rb
@@ -1,7 +1,7 @@
 module MobilizeAmericaClient
   class Client
     module Events
-      def organization_events(organization_id:, updated_since: nil, max_distance_miles: nil, page: nil, per_page: nil,
+      def organization_events(organization_id:, timeslot_start: nil, updated_since: nil, max_distance_miles: nil, page: nil, per_page: nil,
                               zipcode: nil)
         params = {}
 
@@ -11,6 +11,10 @@ module MobilizeAmericaClient
 
         unless per_page.nil?
           params[:per_page] = per_page
+        end
+
+        unless timeslot_start.nil?
+          params[:timeslot_start] = timeslot_start
         end
 
         unless updated_since.nil?

--- a/spec/client/events_spec.rb
+++ b/spec/client/events_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe MobilizeAmericaClient::Client::Events do
       expect(subject.organization_events(organization_id: org_id, timeslot_start: timeslot_start)).to eq response
     end
 
+    it 'should support a timeslot_end parameter' do
+      timeslot_end = "gte_#{Time.new.to_i}"
+      stub_request(:get, events_url)
+        .with(headers: standard_headers, query: {timeslot_end: timeslot_end})
+        .to_return(body: response.to_json)
+      expect(subject.organization_events(organization_id: org_id, timeslot_end: timeslot_end)).to eq response
+    end
+
+
     it 'should support an updated_since parameter' do
       updated_since = Time.new
       stub_request(:get, events_url)

--- a/spec/client/events_spec.rb
+++ b/spec/client/events_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe MobilizeAmericaClient::Client::Events do
       expect(subject.organization_events(organization_id: 'foo/bar')).to eq response
     end
 
+    it 'should support a timeslot_start parameter' do
+      timeslot_start = "gte_#{Time.new.to_i}"
+      stub_request(:get, events_url)
+        .with(headers: standard_headers, query: {timeslot_start: timeslot_start})
+        .to_return(body: response.to_json)
+      expect(subject.organization_events(organization_id: org_id, timeslot_start: timeslot_start)).to eq response
+    end
+
     it 'should support an updated_since parameter' do
       updated_since = Time.new
       stub_request(:get, events_url)


### PR DESCRIPTION
Adds ability to specify on `organisation_events` API call, `timeslot_start` query param. 