### PR TITLE
RateLimitedError includes retry_after attribute

### DIFF
--- a/lib/mobilize_america_client/errors.rb
+++ b/lib/mobilize_america_client/errors.rb
@@ -12,9 +12,7 @@ module MobilizeAmericaClient
     attr_reader :retry_after
 
     def initialize(message, retry_after: nil)
-      if retry_after
-        @retry_after = Integer(retry_after)
-      end
+      @retry_after = Integer(retry_after, exception: false)
 
       super(message)
     end

--- a/lib/mobilize_america_client/errors.rb
+++ b/lib/mobilize_america_client/errors.rb
@@ -9,6 +9,15 @@ module MobilizeAmericaClient
   end
 
   class RateLimitedError < ClientError
+    attr_reader :retry_after
+
+    def initialize(message, retry_after: nil)
+      if retry_after
+        @retry_after = Integer(retry_after)
+      end
+
+      super(message)
+    end
   end
 
   class ServerError < StandardError

--- a/lib/mobilize_america_client/request.rb
+++ b/lib/mobilize_america_client/request.rb
@@ -36,7 +36,7 @@ module MobilizeAmericaClient
       when 429
         retry_after_header = response.headers['Retry-After']
         message = "Rate Limited (Retry-After #{retry_after_header}): #{response.body}"
-        raise MobilizeAmericaClient::RateLimitedError, message
+        raise MobilizeAmericaClient::RateLimitedError.new(message, retry_after: retry_after_header)
       when 400..499
         raise MobilizeAmericaClient::ClientError, "Client Error (#{response.status}): #{response.body}"
       when 500..599

--- a/spec/shared_examples/response_error_handling.rb
+++ b/spec/shared_examples/response_error_handling.rb
@@ -45,11 +45,16 @@ RSpec.shared_examples_for 'response error handling' do
     let(:response_status) { 429 }
     let(:response_body) { {error: 'rate-limited'}.to_json }
 
-    it 'should raise RateLimitedError' do
-      expect{ call_client_method.call }.to raise_error(MobilizeAmericaClient::RateLimitedError)
+    context 'without a Retry-After header' do
+      it 'should raise RateLimitedError' do
+        expect{ call_client_method.call }.to raise_error do |error|
+          expect(error).to be_a MobilizeAmericaClient::RateLimitedError
+          expect(error.retry_after).to be_nil
+        end
+      end
     end
 
-    context 'with a Retry-After header' do
+    context 'with a valid Retry-After header' do
       let(:response_headers) { {'Content-Type' => 'application/json', 'Retry-After' => '3600'} }
 
       it 'should include that info in the error' do
@@ -57,6 +62,17 @@ RSpec.shared_examples_for 'response error handling' do
           expect(error).to be_a MobilizeAmericaClient::RateLimitedError
           expect(error.message).to include '3600'
           expect(error.retry_after).to eq 3600
+        end
+      end
+    end
+
+    context 'with an invalid Retry-After header' do
+      let(:response_headers) { {'Content-Type' => 'application/json', 'Retry-After' => 'pigs fly'} }
+
+      it 'should ignore it' do
+        expect{ call_client_method.call }.to raise_error do |error|
+          expect(error).to be_a MobilizeAmericaClient::RateLimitedError
+          expect(error.retry_after).to be_nil
         end
       end
     end

--- a/spec/shared_examples/response_error_handling.rb
+++ b/spec/shared_examples/response_error_handling.rb
@@ -52,8 +52,12 @@ RSpec.shared_examples_for 'response error handling' do
     context 'with a Retry-After header' do
       let(:response_headers) { {'Content-Type' => 'application/json', 'Retry-After' => '3600'} }
 
-      it 'should raise include that info in the error' do
-        expect{ call_client_method.call }.to raise_error(MobilizeAmericaClient::RateLimitedError, /3600/)
+      it 'should include that info in the error' do
+        expect{ call_client_method.call }.to raise_error do |error|
+          expect(error).to be_a MobilizeAmericaClient::RateLimitedError
+          expect(error.message).to include '3600'
+          expect(error.retry_after).to eq 3600
+        end
       end
     end
   end


### PR DESCRIPTION
When we receive a 429 response from the Mobilize API, we raise a RateLimitedError. If the 429 response included a `Retry-After` header, we include that information in the error message, like "Rate Limited (Retry-After 600)".

This PR adds a `retry_after` attribute to `RateLimitedError`, so that clients can programmatically read the information and use it to inform how they handle the error.